### PR TITLE
Patch overlap

### DIFF
--- a/gb_code/gb_generator.py
+++ b/gb_code/gb_generator.py
@@ -287,10 +287,10 @@ class GB_character:
         """
         finds the overlapping atoms.
         """
-        IndX = np.where([self.atoms1[:, 0] < 1])[1]
-        IndY = np.where([self.atoms2[:, 0] > -1])[1]
-        X_new = self.atoms1[self.atoms1[:, 0] < 1]
-        Y_new = self.atoms2[self.atoms2[:, 0] > -1]
+        IndX = np.where(self.atoms1[:, 0] < 1)[0]
+        IndY = np.where(self.atoms2[:, 0] > -1)[0]
+        X_new = self.atoms1[IndX]
+        Y_new = self.atoms2[IndY]
         x = np.arange(0, len(X_new), 1)
         y = np.arange(0, len(Y_new), 1)
         indice = (np.stack(np.meshgrid(x, y)).T).reshape(len(x) * len(y), 2)

--- a/gb_code/gb_generator.py
+++ b/gb_code/gb_generator.py
@@ -113,22 +113,26 @@ class GB_character:
                     sys.exit()
 
             xdel, ydel, x_indice, y_indice = self.Find_overlapping_Atoms()
-            print ("<<------ {} atoms are being removed! ------>>"
-                    .format(len(xdel)))
 
             if self.whichG == "G1" or self.whichG == "g1":
                 self.atoms1 = np.delete(self.atoms1, x_indice, axis=0)
                 xdel[:, 0] = xdel[:, 0] + norm(self.ortho1[:, 0])
                 self.atoms1 = np.vstack((self.atoms1, xdel))
+                n_deleted = len(xdel)
 
             elif self.whichG == "G2" or self.whichG == "g2":
                 self.atoms2 = np.delete(self.atoms2, y_indice, axis=0)
                 ydel[:, 0] = ydel[:, 0] - norm(self.ortho1[:, 0])
                 self.atoms2 = np.vstack((self.atoms2, ydel))
+                n_deleted = len(ydel)
 
             else:
                 print("You must choose either 'g1', 'g2' ")
                 sys.exit()
+
+            print ("<<------ {} atoms are being removed! ------>>"
+                    .format(n_deleted))
+
             self.Expand_Super_cell()
             if not self.trans:
                 count = 0

--- a/gb_code/gb_generator.py
+++ b/gb_code/gb_generator.py
@@ -261,30 +261,27 @@ class GB_character:
         """
         expands the smallest CSL unitcell to the given dimensions.
         """
+        # Calculate unit cell displacements along each axis
         a = norm(self.ortho1[:, 0])
         b = norm(self.ortho1[:, 1])
         c = norm(self.ortho1[:, 2])
         dimX, dimY, dimZ = self.dim
 
-        X = self.atoms1.copy()
-        Y = self.atoms2.copy()
+        x1_shifts = a * np.arange(dimX)
+        x2_shifts = -a * np.arange(dimX)
+        y_shifts = b * np.arange(dimY)
+        z_shifts = c * np.arange(dimZ)
+        
+        # Get all unique combinations of the shifts
+        g1_shifts = np.array(np.meshgrid(x1_shifts, y_shifts, z_shifts)).T.reshape(-1, 3)
+        g2_shifts = np.array(np.meshgrid(x2_shifts, y_shifts, z_shifts)).T.reshape(-1, 3)
 
-        X_new = []
-        Y_new = []
-        for i in range(dimX):
-            for j in range(dimY):
-                for k in range(dimZ):
-                    Position1 = [i * a, j * b, k * c]
-                    Position2 = [-i * a, j * b, k * c]
-                    for l in range(len(X)):
-                        X_new.append(Position1[0:3] + X[l, 0:3])
-                    for m in range(len(Y)):
-                        Y_new.append(Position2[0:3] + Y[m, 0:3])
-
-        self.atoms1 = np.array(X_new)
-        self.atoms2 = np.array(Y_new)
-
-        return
+        # Duplicate every atom for each available shift
+        copy1 = self.atoms1.copy()
+        copy2 = self.atoms2.copy()
+        
+        self.atoms1 = copy1.repeat(len(g1_shifts), axis=0) + np.tile(g1_shifts, (len(copy1), 1))
+        self.atoms2 = copy2.repeat(len(g2_shifts), axis=0) + np.tile(g2_shifts, (len(copy2), 1))
 
     def Find_overlapping_Atoms(self):
 

--- a/gb_code/gb_generator.py
+++ b/gb_code/gb_generator.py
@@ -100,19 +100,21 @@ class GB_character:
         self.File = file
         self.Expand_Super_cell()
         
+        if self.trans:
+            # Ensure needed variables exist before wasting time on computation
+            try:
+                a = int(kwargs['a'])
+                b = int(kwargs['b'])
+            except:
+                print('Make sure the a and b integers are there!')
+                sys.exit()
+        
         if self.overD > 0:
             try:
                 self.whichG = kwargs['whichG']
             except:
                 print('decide on whichG!')
                 sys.exit()
-            if self.trans:
-                try:
-                    a = int(kwargs['a'])
-                    b = int(kwargs['b'])
-                except:
-                    print('Make sure the a and b integers are there!')
-                    sys.exit()
 
             xdel, ydel, x_indice, y_indice = self.Find_overlapping_Atoms()
 
@@ -121,55 +123,34 @@ class GB_character:
                 xdel[:, 0] += norm(self.ortho1[:, 0])
                 self.atoms1 = np.vstack((self.atoms1, xdel))
                 n_deleted = len(xdel)
-
             elif self.whichG == "G2" or self.whichG == "g2":
                 self.atoms2 = np.delete(self.atoms2, y_indice, axis=0)
                 ydel[:, 0] -= norm(self.ortho1[:, 0])
                 self.atoms2 = np.vstack((self.atoms2, ydel))
                 n_deleted = len(ydel)
-
             else:
                 print("You must choose either 'g1', 'g2' ")
                 sys.exit()
 
             print ("<<------ {} atoms are being removed! ------>>"
                     .format(n_deleted))
-
-            if not self.trans:
-                count = 0
-                print ("<<------ 1 GB structure is being created! ------>>")
-                if self.File == "LAMMPS":
-                    self.Write_to_Lammps(count)
-                elif self.File == "VASP":
-                    self.Write_to_Vasp(count)
-                else:
-                    print("The output file must be either LAMMPS or VASP!")
-            elif self.trans:
-                self.Translate(a, b)
-
         elif self.overD == 0:
-            if self.trans:
-                try:
-                    a = int(kwargs['a'])
-                    b = int(kwargs['b'])
-                except:
-                    print('Make sure the a and b integers are there!')
-                    sys.exit()
-                print ("<<------ 0 atoms are being removed! ------>>")
-                self.Translate(a, b)
-
-            else:
-                count = 0
-                print ("<<------ 1 GB structure is being created! ------>>")
-                if self.File == "LAMMPS":
-                    self.Write_to_Lammps(count)
-                elif self.File == "VASP":
-                    self.Write_to_Vasp(count)
-                else:
-                    print("The output file must be either LAMMPS or VASP!")
+            print ("<<------ 0 atoms are being removed! ------>>")
         else:
             print('Overlap distance is not inputted incorrectly!')
             sys.exit()
+
+        if not self.trans:
+            count = 0
+            print ("<<------ 1 GB structure is being created! ------>>")
+            if self.File == "LAMMPS":
+                self.Write_to_Lammps(count)
+            elif self.File == "VASP":
+                self.Write_to_Vasp(count)
+            else:
+                print("The output file must be either LAMMPS or VASP!")
+        elif self.trans:
+            self.Translate(a, b)
 
     def CSL_Ortho_unitcell_atom_generator(self):
 

--- a/gb_code/gb_generator.py
+++ b/gb_code/gb_generator.py
@@ -116,13 +116,13 @@ class GB_character:
 
             if self.whichG == "G1" or self.whichG == "g1":
                 self.atoms1 = np.delete(self.atoms1, x_indice, axis=0)
-                xdel[:, 0] = xdel[:, 0] + norm(self.ortho1[:, 0])
+                xdel[:, 0] += norm(self.ortho1[:, 0])
                 self.atoms1 = np.vstack((self.atoms1, xdel))
                 n_deleted = len(xdel)
 
             elif self.whichG == "G2" or self.whichG == "g2":
                 self.atoms2 = np.delete(self.atoms2, y_indice, axis=0)
-                ydel[:, 0] = ydel[:, 0] - norm(self.ortho1[:, 0])
+                ydel[:, 0] -= norm(self.ortho1[:, 0])
                 self.atoms2 = np.vstack((self.atoms2, ydel))
                 n_deleted = len(ydel)
 

--- a/gb_code/gb_generator.py
+++ b/gb_code/gb_generator.py
@@ -98,6 +98,8 @@ class GB_character:
         self.trans = rigid
         self.dim = np.array([int(dim1), int(dim2), int(dim3)])
         self.File = file
+        self.Expand_Super_cell()
+        
         if self.overD > 0:
             try:
                 self.whichG = kwargs['whichG']
@@ -133,7 +135,6 @@ class GB_character:
             print ("<<------ {} atoms are being removed! ------>>"
                     .format(n_deleted))
 
-            self.Expand_Super_cell()
             if not self.trans:
                 count = 0
                 print ("<<------ 1 GB structure is being created! ------>>")
@@ -155,11 +156,9 @@ class GB_character:
                     print('Make sure the a and b integers are there!')
                     sys.exit()
                 print ("<<------ 0 atoms are being removed! ------>>")
-                self.Expand_Super_cell()
                 self.Translate(a, b)
 
             else:
-                self.Expand_Super_cell()
                 count = 0
                 print ("<<------ 1 GB structure is being created! ------>>")
                 if self.File == "LAMMPS":


### PR DESCRIPTION
This patch add PBC treatment for the deletion of overlapping atoms.

I noticed that my Sigma5 \[001\]\(130\) symmetric tilt was behaving strangely, and found that the code wasn't accounting for the deletion of overlap at second boundary (i.e. the one not at `x=0`).

**Behaviour before:**

`overlap=0.2`, no deletion (correctly)
![overlap=0.2](https://user-images.githubusercontent.com/20283329/55738692-e3961900-5a27-11e9-87c6-c363415cafb9.png)
`overlap=0.4`, correct deletion at one GB, none at the other and an extra atom
![before_4](https://user-images.githubusercontent.com/20283329/55738822-2d7eff00-5a28-11e9-836c-987ea0d1b6b4.png)
`overlap=0.8`, correct deletion at one GB, no deletion and extra atoms at the other
![before_8](https://user-images.githubusercontent.com/20283329/55738834-31ab1c80-5a28-11e9-8945-dcc515decfe9.png)

I moved the extension of the supercell before all the overlap checks, added checks separately for the `x=0` and `x=0.5 * L` GBs, and added brute-force PBC checks in the YZ-plane.

**Behaviour after:** Overlaps of 0.2, 0.4, and 0.8, desired behaviour in each instance

![after_2](https://user-images.githubusercontent.com/20283329/55739020-86e72e00-5a28-11e9-8c5e-573f38503bb7.png)
![after_4](https://user-images.githubusercontent.com/20283329/55739021-86e72e00-5a28-11e9-9391-d1656c1a1f30.png)
![after_8](https://user-images.githubusercontent.com/20283329/55739022-86e72e00-5a28-11e9-9e85-1690b396525c.png)


