### PR TITLE
Fixed yaml.load issue -> yaml.safe_load

### DIFF
--- a/gb_code/gb_generator.py
+++ b/gb_code/gb_generator.py
@@ -475,7 +475,7 @@ def main():
     if len(sys.argv) == 2:
         io_file = sys.argv[1]
         file = open(io_file, 'r')
-        in_params = yaml.load(file)
+        in_params = yaml.safe_load(file)
 
         try:
             axis = np.array(in_params['axis'])


### PR DESCRIPTION
Newer versions of Python's yaml module require "loader=Loader" explicitly in calls to yaml.load(). Changing that line in gb_generator.py to "yaml.safe_load()" fixes the problem.